### PR TITLE
Replaced ix with iloc

### DIFF
--- a/pscore_match/match.py
+++ b/pscore_match/match.py
@@ -397,7 +397,7 @@ def whichMatched(matches, data, show_duplicates = True):
             while j>0:
                 indices.append(i)
                 j -= 1
-        return data.ix[indices]
+        return data.iloc[indices]
     else:
         dat2 = data.copy()
         dat2['weights'] = matches.weights


### PR DESCRIPTION
.ix has been deprecated which meant the matching didn't work for me.

I made a 1-line change to match.py, replacing the `.ix` call with `.iloc`.

I tested the change in my local copy and it seemed to fix the error, but I have made this change directly to github so haven't verified that my suggestion works.

P.S. Thanks for an amazing package!